### PR TITLE
Add unit tests for ideal.sylph.controller.utils.JsonFormatUtil

### DIFF
--- a/sylph-controller/src/test/java/ideal/sylph/controller/utils/JsonFormatUtilTest.java
+++ b/sylph-controller/src/test/java/ideal/sylph/controller/utils/JsonFormatUtilTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 The Sylph Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ideal.sylph.controller.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JsonFormatUtilTest {
+
+  @Test
+  public void testFormatJsonDefault() {
+    Assert.assertEquals("fooBar", JsonFormatUtil.formatJson("fooBar"));
+  }
+
+  @Test
+  public void testFormatJsonNull() {
+    Assert.assertEquals("", JsonFormatUtil.formatJson(null));
+    Assert.assertEquals("", JsonFormatUtil.formatJson(""));
+  }
+
+  @Test
+  public void testFormatJsonComma() {
+    Assert.assertEquals("\\,", JsonFormatUtil.formatJson("\\,"));
+    Assert.assertEquals(",\n\\", JsonFormatUtil.formatJson(",\\"));
+  }
+
+  @Test
+  public void testFormatJsonOpenBracket() {
+    Assert.assertEquals("foo{\n  ", JsonFormatUtil.formatJson("foo{"));
+    Assert.assertEquals("foo[\n  ", JsonFormatUtil.formatJson("foo["));
+  }
+
+  @Test
+  public void testFormatJsonCloseBracket() {
+    Assert.assertEquals("foo\n}", JsonFormatUtil.formatJson("foo}"));
+    Assert.assertEquals("foo\n]", JsonFormatUtil.formatJson("foo]"));
+  }
+
+  @Test
+  public void testPrintJson() {
+    Assert.assertEquals("{\n  [\n    foo,\n    Bar\\,123\n  ]\n}",
+            JsonFormatUtil.printJson("{[foo,Bar\\,123]}"));
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `ideal.sylph.controller.utils.JsonFormatUtil` in the `sylph-controller` module is not fully tested.

I've written some tests that cover this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.